### PR TITLE
feat: configure backend api connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ pnpm install
 pnpm dev
 ```
 
+To connect to a real backend service instead of the default mock server, update the `apps/web-antd/.env.development` file:
+
+```bash
+VITE_GLOB_API_URL=http://localhost:8000/api
+VITE_NITRO_MOCK=false
+```
+
+Replace the URL with your backend API endpoint.
+
 4. Build
 
 ```bash

--- a/apps/web-antd/.env.development
+++ b/apps/web-antd/.env.development
@@ -4,10 +4,10 @@ VITE_PORT=5666
 VITE_BASE=/
 
 # 接口地址
-VITE_GLOB_API_URL=/api
+VITE_GLOB_API_URL=http://localhost:8000/api
 
 # 是否开启 Nitro Mock服务，true 为开启，false 为关闭
-VITE_NITRO_MOCK=true
+VITE_NITRO_MOCK=false
 
 # 是否打开 devtools，true 为打开，false 为关闭
 VITE_DEVTOOLS=false


### PR DESCRIPTION
## Summary
- document configuring real backend API URL
- disable mock service and point development env to backend

## Testing
- `pnpm lint`
- `pnpm test:unit` (fails: connect ENETUNREACH to cdnjs)

------
https://chatgpt.com/codex/tasks/task_e_689eeb4f2ce4832daf1264f94d76101b